### PR TITLE
docs: Latest CLI is @hubspot/cli vs @hubspot/cms-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For more information on local development tools, see [Local Development Tooling:
 
 ### Configuration
 
-#### Set up HubSpot CMS CLI ([`@hubspot/cms-cli`](https://www.npmjs.com/package/@hubspot/cms-cli))
+#### Set up HubSpot CMS CLI ([`@hubspot/cli`](https://www.npmjs.com/package/@hubspot/cli))
 - A config file named `hubspot.config.yml` will also be needed.  The config can be at the project level or higher up in the directory tree.
 - Be sure to set a `defaultPortal` in your `hubspot.config.yml` to which you'd like the built app files to sync.
 
@@ -21,7 +21,7 @@ For more information on local development tools, see [Local Development Tooling:
 ### package.json scripts
 - `start` : Builds project with webpack, uploads to your `defaultPortal` specified in `hubspot.config.yml` and watches for changes via [`@hubspot/webpack-cms-plugins/HubSpotAutoUploadPlugin`](https://www.npmjs.com/package/@hubspot/webpack-cms-plugins).
 - `build` : Clears `/dist` contents and builds project into `/dist`.
-- `deploy` : Clears `/dist` contents, builds project into `/dist`, and uploads to via [`@hubspot/cms-cli`](https://www.npmjs.com/package/@hubspot/cms-cli).
+- `deploy` : Clears `/dist` contents, builds project into `/dist`, and uploads to via [`@hubspot/cli`](https://www.npmjs.com/package/@hubspot/cli).
 - `lint` : Lints CSS, JS, and JSON files via `eslint` ([documentation](https://eslint.org/docs/user-guide/configuring)) and checks for formatting via `prettier`([documentation](https://prettier.io/docs/en/configuration.html)) in `src`.
   - For configs, see `prettier.config.js` and `eslintrc.js`.
 - `prettier:write` : Formats JS and JSON files in `src`.


### PR DESCRIPTION
I noticed this while going through the getting started guide for [JS Frameworks](https://developers.hubspot.com/docs/cms/guides/js-frameworks).

/cc @gcorne 