### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-react-boilerplate",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Per breaking changes in https://github.com/HubSpot/cms-react-boilerplate/pull/44:

> After merging I'll plan on bumping the version to `2.0.0`, since the sass dependency update could be a breaking change.

