### PR TITLE
Sync up package.json version to better match previous tag releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-react-boilerplate",
-  "version": "2.0.0",
+  "version": "0.5.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
More from https://github.com/HubSpot/cms-react-boilerplate/pull/44#issuecomment-1144869353:

> However, I see that the the previous version tags were disconnected from the version in package.json (`1.0.0`). Hmm...
> 
> I think I'm going to change the package.json version to match the previous version releases (`v0.5.0`) and then tag and "publish" a new release.

I hope that changing this package.json version number to a lower one doesn't mess any existing setups. Though since this is not a package actually published on npm, I'm not _too_ worried about it. And I feel that the `0.x` version better matches the beta state of the repo. Apologies for the churn folx.